### PR TITLE
Ephemeral + nixpkgs 25.05

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,14 +1,18 @@
+import? 'scripts/recipes-aws.just'
+
 set shell := ["nu", "-c"]
 set positional-arguments
 
 default:
   just --list
 
-apply-all:
-  colmena apply --verbose
-
+# Deploy select machines
 apply *ARGS:
-  colmena apply --verbose --on {{ARGS}}
+  colmena apply --verbose --experimental-flake-eval --on {{ARGS}}
+
+# Deploy all machines
+apply-all *ARGS:
+  colmena apply --verbose --experimental-flake-eval {{ARGS}}
 
 ssh HOSTNAME *ARGS:
   #!/usr/bin/env nu

--- a/Justfile
+++ b/Justfile
@@ -8,11 +8,11 @@ default:
 
 # Deploy select machines
 apply *ARGS:
-  colmena apply --verbose --experimental-flake-eval --nix-option accept-flake-config true --on {{ARGS}}
+  colmena apply --verbose --nix-option accept-flake-config true --on {{ARGS}}
 
 # Deploy all machines
 apply-all *ARGS:
-  colmena apply --verbose --experimental-flake-eval --nix-option accept-flake-config true {{ARGS}}
+  colmena apply --verbose --nix-option accept-flake-config true {{ARGS}}
 
 ssh HOSTNAME *ARGS:
   #!/usr/bin/env nu
@@ -29,7 +29,7 @@ ssh-for-all *ARGS:
   $nodes | par-each {|node| just ssh -q $node {{ARGS}} }
 
 ssh-for-each HOSTNAMES *ARGS:
-  colmena exec --verbose --experimental-flake-eval --parallel 0 --nix-option accept-flake-config true --on {{HOSTNAMES}} {{ARGS}}
+  colmena exec --verbose --parallel 0 --nix-option accept-flake-config true --on {{HOSTNAMES}} {{ARGS}}
 
 gc-all:
   #!/usr/bin/env nu

--- a/Justfile
+++ b/Justfile
@@ -8,11 +8,11 @@ default:
 
 # Deploy select machines
 apply *ARGS:
-  colmena apply --verbose --experimental-flake-eval --on {{ARGS}}
+  colmena apply --verbose --experimental-flake-eval --nix-option accept-flake-config true --on {{ARGS}}
 
 # Deploy all machines
 apply-all *ARGS:
-  colmena apply --verbose --experimental-flake-eval {{ARGS}}
+  colmena apply --verbose --experimental-flake-eval --nix-option accept-flake-config true {{ARGS}}
 
 ssh HOSTNAME *ARGS:
   #!/usr/bin/env nu

--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ ssh-for-all *ARGS:
   $nodes | par-each {|node| just ssh -q $node {{ARGS}} }
 
 ssh-for-each HOSTNAMES *ARGS:
-  colmena exec --verbose --experimental-flake-eval --parallel 0 --on {{HOSTNAMES}} {{ARGS}}
+  colmena exec --verbose --experimental-flake-eval --parallel 0 --nix-option accept-flake-config true --on {{HOSTNAMES}} {{ARGS}}
 
 gc-all:
   #!/usr/bin/env nu

--- a/Justfile
+++ b/Justfile
@@ -23,10 +23,13 @@ ssh HOSTNAME *ARGS:
 
   ssh -F .ssh_config {{HOSTNAME}} {{ARGS}}
 
-ssh-for-each *ARGS:
+ssh-for-all *ARGS:
   #!/usr/bin/env nu
   let nodes = (nix eval --json '.#nixosConfigurations' --apply builtins.attrNames | from json)
   $nodes | par-each {|node| just ssh -q $node {{ARGS}} }
+
+ssh-for-each HOSTNAMES *ARGS:
+  colmena exec --verbose --experimental-flake-eval --parallel 0 --on {{HOSTNAMES}} {{ARGS}}
 
 gc-all:
   #!/usr/bin/env nu

--- a/flake.lock
+++ b/flake.lock
@@ -95,22 +95,22 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "nixpkgs"
         ],
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1684127108,
-        "narHash": "sha256-01bfuSY4gnshhtqA1EJCw2CMsKkAx+dHS+sEpQ2+EAQ=",
+        "lastModified": 1734897875,
+        "narHash": "sha256-LLpiqfOGBippRax9F33kSJ/Imt8gJXb6o0JwSBiNHCk=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "5fdd743a11e7291bd8ac1e169d62ba6156c99be4",
+        "rev": "a6b51f5feae9bfb145daa37fd0220595acb7871e",
         "type": "github"
       },
       "original": {
         "owner": "zhaofengli",
-        "ref": "v0.4.0",
         "repo": "colmena",
         "type": "github"
       }
@@ -372,6 +372,27 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "colmena",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1677543769,
@@ -492,16 +513,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1701263465,
-        "narHash": "sha256-lNXUIlkfyDyp9Ox21hr+wsEf/IBklLvb6bYcyeXbdRc=",
+        "lastModified": 1748162331,
+        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "50aa30a13c4ab5e7ba282da460a3e3d44e9d0eb3",
+        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -604,16 +625,16 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1669735802,
-        "narHash": "sha256-qtG/o/i5ZWZLmXw108N2aPiVsxOcidpHJYNkT45ry9Q=",
+        "lastModified": 1730883749,
+        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "731cc710aeebecbf45a258e977e8b68350549522",
+        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1734897875,
-        "narHash": "sha256-LLpiqfOGBippRax9F33kSJ/Imt8gJXb6o0JwSBiNHCk=",
+        "lastModified": 1749409980,
+        "narHash": "sha256-I/Tvv5UN5DRYXTEy/+j7mYRsdoWQ+rCfrVoNEw0K/Ek=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "a6b51f5feae9bfb145daa37fd0220595acb7871e",
+        "rev": "58f1beb074881d7208def140af71b7864b6139e0",
         "type": "github"
       },
       "original": {
@@ -625,16 +625,16 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1730883749,
-        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,39 +1,20 @@
 {
   "nodes": {
-    "ameba-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1679041484,
-        "narHash": "sha256-pc9mtVR/PBhM5l1PnDkm+y+McxbrfAmQzxmLi761VF4=",
-        "owner": "crystal-ameba",
-        "repo": "ameba",
-        "rev": "7c74d196d6d9a496a81a0c7b79ef44f39faf41b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crystal-ameba",
-        "ref": "v1.4.3",
-        "repo": "ameba",
-        "type": "github"
-      }
-    },
     "auth-keys-hub": {
       "inputs": {
-        "crystal": "crystal",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "inclusive": "inclusive",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "statix": "statix",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1691483346,
-        "narHash": "sha256-wvn84eGcc+PMbq/qSCWcZ/kV7/bjwuGOVSn/9rGaaKw=",
+        "lastModified": 1747252629,
+        "narHash": "sha256-3VbgOFf3pEo+HGB5vIPxOwe4R2M7qU+VJ+5iS4hBKqI=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "ab7c79f49886b8f24cfae4b967a59ea62af9156e",
+        "rev": "dd1d9361407457d14bab8f946d10062c487304df",
         "type": "github"
       },
       "original": {
@@ -74,23 +55,6 @@
         "type": "github"
       }
     },
-    "bdwgc-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661523039,
-        "narHash": "sha256-UYJQGeSykmfydGAmTlNJNyAPBasBkddOSoopBHiY7TI=",
-        "owner": "ivmai",
-        "repo": "bdwgc",
-        "rev": "cd1fbc1dbfd2cc888436944dd2784f39820698d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ivmai",
-        "ref": "v8.2.2",
-        "repo": "bdwgc",
-        "type": "github"
-      }
-    },
     "colmena": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -115,102 +79,6 @@
         "type": "github"
       }
     },
-    "crystal": {
-      "inputs": {
-        "ameba-src": "ameba-src",
-        "bdwgc-src": "bdwgc-src",
-        "crystal-aarch64-darwin": "crystal-aarch64-darwin",
-        "crystal-src": "crystal-src",
-        "crystal-x86_64-darwin": "crystal-x86_64-darwin",
-        "crystal-x86_64-linux": "crystal-x86_64-linux",
-        "crystalline-src": "crystalline-src",
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1683429373,
-        "narHash": "sha256-Mx5lwMyk2T40wFqOoYcJLs4srwO2UrsepTZhlHNuTrI=",
-        "owner": "manveru",
-        "repo": "crystal-flake",
-        "rev": "e7a443c20e2be6e5dd870586705dd27c91aa9c5c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "manveru",
-        "repo": "crystal-flake",
-        "type": "github"
-      }
-    },
-    "crystal-aarch64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-NqYaZHM3kHAgYbO0RDJtA8eHqp4vVe4MBpisTOGrRVw=",
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      }
-    },
-    "crystal-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681995387,
-        "narHash": "sha256-t+1vM1m62UftCvfa90Dg6nqt6Zseh/GP/Gc1VfOa4+c=",
-        "owner": "crystal-lang",
-        "repo": "crystal",
-        "rev": "a59a3dbd738269d5aad6051c3834fc70f482f469",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crystal-lang",
-        "ref": "1.8.1",
-        "repo": "crystal",
-        "type": "github"
-      }
-    },
-    "crystal-x86_64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-NqYaZHM3kHAgYbO0RDJtA8eHqp4vVe4MBpisTOGrRVw=",
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      }
-    },
-    "crystal-x86_64-linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-/Jk3uiglM/hzjygxmMUgVTvz+tuFFjBv8+uUIL05rXo=",
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-linux-x86_64.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-linux-x86_64.tar.gz"
-      }
-    },
-    "crystalline-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681549124,
-        "narHash": "sha256-kx3rdGqIbrOaHY7V3uXLqIFEYzzsMKzNwZ6Neq8zM3c=",
-        "owner": "elbywan",
-        "repo": "crystalline",
-        "rev": "4ac0ae282c5f4172230fea1e93df51c2b380f475",
-        "type": "github"
-      },
-      "original": {
-        "owner": "elbywan",
-        "ref": "v0.9.0",
-        "repo": "crystalline",
-        "type": "github"
-      }
-    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -228,29 +96,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "disko",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "auth-keys-hub",
-          "statix",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1645251813,
-        "narHash": "sha256-cQ66tGjnZclBCS3nD26mZ5fUH+3/HnysGffBiWXUSHk=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "9892337b588c38ec59466a1c89befce464aae7f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
         "type": "github"
       }
     },
@@ -275,24 +120,6 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1672152762,
-        "narHash": "sha256-U8iWWHgabN07zfbgedogMVWrEP1Zywyf3Yx3OYHSSgE=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "19e0f88324d90509141e192664ded98bb88ef9b2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
-      },
-      "locked": {
         "lastModified": 1682984683,
         "narHash": "sha256-fSMthG+tp60AHhNmaHc4StT3ltfHkQsJtN8GhfLWmtI=",
         "owner": "hercules-ci",
@@ -306,9 +133,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_2": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1683560683,
@@ -395,39 +222,21 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677543769,
-        "narHash": "sha256-LwbqS8vGisXl2WHpK9r5+kodr0zoIT8F2YB0R4y1TsA=",
-        "owner": "NixOS",
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b26d52c9feb6476580016e78935cbf96eb3e2115",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1671359686,
-        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs-lib_2": {
+    "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
         "lastModified": 1682879489,
@@ -445,7 +254,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
         "lastModified": 1682879489,
@@ -481,38 +290,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1645013224,
-        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1748162331,
         "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
         "owner": "nixos",
@@ -527,7 +304,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1690026219,
         "narHash": "sha256-oOduRk/kzQxOBknZXTLSEYd7tk+GoKvr8wV6Ab+t4AU=",
@@ -543,7 +320,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1636823747,
         "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
@@ -579,34 +356,17 @@
         "auth-keys-hub": "auth-keys-hub",
         "colmena": "colmena",
         "disko": "disko",
-        "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_4",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2",
         "opentofu-registry": "opentofu-registry",
         "sops-nix": "sops-nix",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix_2"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645205556,
-        "narHash": "sha256-e4lZW3qRyOEJ+vLKFQP7m2Dxh5P44NrnekZYLxlucww=",
-        "owner": "rust-analyzer",
-        "repo": "rust-analyzer",
-        "rev": "acf5874b39f3dc5262317a6074d9fc7285081161",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-analyzer",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -639,25 +399,6 @@
         "type": "github"
       }
     },
-    "statix": {
-      "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1676888642,
-        "narHash": "sha256-C73LOMVVCkeL0jA5xN7klLEDEB4NkuiATEJY4A/tIyM=",
-        "owner": "nerdypepper",
-        "repo": "statix",
-        "rev": "3c7136a23f444db252a556928c1489869ca3ab4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nerdypepper",
-        "repo": "statix",
-        "type": "github"
-      }
-    },
     "stdlib": {
       "locked": {
         "lastModified": 1590026685,
@@ -678,7 +419,7 @@
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_4",
         "terranix-examples": "terranix-examples"
       },
       "locked": {
@@ -712,7 +453,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1683117219,

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,12 @@
   inputs = {
     auth-keys-hub.url = "github:input-output-hk/auth-keys-hub";
     auth-keys-hub.inputs.nixpkgs.follows = "nixpkgs";
-    colmena.url = "github:zhaofengli/colmena/v0.4.0";
+    colmena.url = "github:zhaofengli/colmena";
     colmena.inputs.nixpkgs.follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     sops-nix.url = "github:Mic92/sops-nix";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -75,24 +75,19 @@ in {
 
     perf-class = mkClass "perf";
 
-    inherit (nixosModules) common nomad-client nomad-server deployer nix-private;
+    inherit (nixosModules) common ephemeral nomad-client nomad-server nomad-ssd deployer nix-private;
   in
     {
       meta.nixpkgs = import inputs.nixpkgs {system = "x86_64-linux";};
       defaults.imports = [common nixos-23-05];
     }
     # change when we have an actual SSD
-    # // (mkNodes 1 "client-ssd-eu-%02d" "10.200.21.%d" [(type "r5.4xlarge") nomad-client nomad-ssd perf-ssd-class (ebs 128) eu-central-1b])
-    # // (mkNodes 1 "client-ssd-us-%02d" "10.200.22.%d" [(type "r5d.4xlarge") nomad-client nomad-ssd perf-ssd-class (ebs 128) eu-central-1b])
     // (mkNode "leader" "10.200.0.1" [eu-central-1c (type "r5.xlarge") nomad-server (ebs 40)])
     // (mkNode "deployer" "10.200.0.2" [eu-central-1b (type "c5.9xlarge") deployer nix-private (ebs 2000)])
     // (mkNode "explorer" "10.200.1.19" [eu-central-1b (type "m5.4xlarge") nomad-client perf-class (ebs 40)])
-    # // (mkNodes 19 "client-ssd-eu-%02d" "10.200.21.%d" [(type "r5d.4xlarge") nix-private nomad-client nomad-ssd perf-ssd-class (ebs 40) eu-central-1b])
-    # // (mkNodes 17 "client-ssd-ap-%02d" "10.200.22.%d" [(type "r5d.4xlarge") nix-private nomad-client nomad-ssd perf-ssd-class (ebs 40) ap-southeast-2b])
-    # // (mkNodes 17 "client-ssd-us-%02d" "10.200.23.%d" [(type "r5d.4xlarge") nix-private nomad-client nomad-ssd perf-ssd-class (ebs 40) us-east-1d])
-    // (mkNodes 18 "client-eu-%02d" "10.200.1.%d" [(type "c5.2xlarge") nomad-client perf-class (ebs 40) eu-central-1b])
-    // (mkNodes 17 "client-ap-%02d" "10.200.2.%d" [(type "c5.2xlarge") nomad-client perf-class (ebs 40) ap-southeast-2b])
-    // (mkNodes 17 "client-us-%02d" "10.200.3.%d" [(type "c5.2xlarge") nomad-client perf-class (ebs 40) us-east-1d]);
+    // (mkNodes 18 "client-eu-%02d" "10.200.1.%d" [(type "c5d.2xlarge") nomad-client nomad-ssd ephemeral perf-class (ebs 40) eu-central-1b])
+    // (mkNodes 17 "client-ap-%02d" "10.200.2.%d" [(type "c5d.2xlarge") nomad-client nomad-ssd ephemeral perf-class (ebs 40) ap-southeast-2b])
+    // (mkNodes 17 "client-us-%02d" "10.200.3.%d" [(type "c5d.2xlarge") nomad-client nomad-ssd ephemeral perf-class (ebs 40) us-east-1d]);
 
   flake.colmenaHive = inputs.colmena.lib.makeHive self.outputs.colmena;
 }

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -2,6 +2,7 @@
   inputs,
   config,
   lib,
+  self,
   ...
 }: let
   inherit (config.flake) nixosModules;
@@ -92,4 +93,6 @@ in {
     // (mkNodes 18 "client-eu-%02d" "10.200.1.%d" [(type "c5.2xlarge") nomad-client perf-class (ebs 40) eu-central-1b])
     // (mkNodes 17 "client-ap-%02d" "10.200.2.%d" [(type "c5.2xlarge") nomad-client perf-class (ebs 40) ap-southeast-2b])
     // (mkNodes 17 "client-us-%02d" "10.200.3.%d" [(type "c5.2xlarge") nomad-client perf-class (ebs 40) us-east-1d]);
+
+  flake.colmenaHive = inputs.colmena.lib.makeHive self.outputs.colmena;
 }

--- a/flake/nixosModules/common.nix
+++ b/flake/nixosModules/common.nix
@@ -66,7 +66,6 @@ parts @ {
     #
     systemd.services.sops-secrets = lib.mkIf (config.system.activationScripts.setupSecrets ? text) {
       wantedBy = ["multi-user.target"];
-      after = ["network-online.target"];
 
       script = config.system.activationScripts.setupSecrets.text;
 

--- a/flake/nixosModules/common.nix
+++ b/flake/nixosModules/common.nix
@@ -153,6 +153,7 @@ parts @ {
     };
 
     services = {
+      amazon-ssm-agent.enable = lib.mkForce false;
       chrony.enable = true;
       cron.enable = true;
       fail2ban.enable = true;

--- a/flake/nixosModules/deployer.nix
+++ b/flake/nixosModules/deployer.nix
@@ -21,7 +21,7 @@
       }
     ];
 
-    systemd.services.mkfs-dev-sdh.after = ["network-online.target"];
+    systemd.services.mkfs-dev-sdh.after = ["multi-user.target"];
 
     environment.systemPackages = with pkgs; [
       (ruby.withPackages (ps: with ps; [sequel pry sqlite3 nokogiri]))

--- a/flake/nixosModules/deployer.nix
+++ b/flake/nixosModules/deployer.nix
@@ -11,8 +11,6 @@
       autoResize = true;
     };
 
-    fileSystems."/".autoResize = true;
-
     swapDevices = [
       {
         device = "/home/swapfile";

--- a/flake/nixosModules/deployer.nix
+++ b/flake/nixosModules/deployer.nix
@@ -4,8 +4,23 @@
 
     aws.instance.tags.Role = "deployer";
 
+    # NOTE: This block device needs to be manually labelled non-destructively
+    # only once so that the block device can be reproducibly remounted on each
+    # reboot.  Otherwise, if the /dev/nvme* path is used to try and mount, it
+    # will randomly break on reboot as AWS non-deterministically assigns block
+    # device names.
+    #
+    # The command to check the label is:
+    #
+    #   blkid | grep devfs
+    #
+    # The command to create a label if no label exists is:
+    #
+    #   e2label /dev/$DEVICE devfs
+    #
+    # Once labelled, the following declaration will reproducibly mount:
     fileSystems."/home" = {
-      device = "/dev/nvme1n1";
+      device = "/dev/disk/by-label/devfs";
       fsType = "ext4";
       autoFormat = true;
       autoResize = true;

--- a/flake/nixosModules/ephemeral.nix
+++ b/flake/nixosModules/ephemeral.nix
@@ -1,0 +1,333 @@
+# nixosModule: profile-aws-ec2-ephemeral
+#
+# Originates from:
+# https://github.com/input-output-hk/cardano-parts/blob/main/flake/nixosModules/profile-aws-ec2-ephemeral.nix
+flake: {
+  flake.nixosModules.ephemeral = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    inherit (builtins) head;
+    inherit (lib) any getExe hasInfix hasPrefix mkForce mkIf mkOption removePrefix splitString;
+    inherit (lib.types) bool enum listOf str;
+    inherit (config.aws.instance) instance_type;
+
+    isDiskBackedStorageType = t: hasInfix "d" (head (splitString "." t));
+    isSpecialType = t: any (_: _) (map (e: hasPrefix e t) cfg.specialEphemeralInstanceTypePrefixes);
+
+    # NVMe containing ephemeral instance types generally need to have a "d" in
+    # the instance type, or belong to a special class.
+    hasEphemeral = isDiskBackedStorageType instance_type || isSpecialType instance_type;
+
+    cfg = config.services.aws.ec2.ephemeral;
+  in {
+    key = ./profile-aws-ec2-ephemeral.nix;
+
+    options.services.aws.ec2.ephemeral = {
+      enableMountOnCreation = mkOption {
+        type = bool;
+        default = true;
+        description = ''
+          Whether to ensure the ephemeral volume is mounted automatically after
+          it becomes available.
+        '';
+      };
+
+      enablePostMountService = mkOption {
+        type = bool;
+        default = true;
+        description = ''
+          Whether to enable post mounting service handling.
+        '';
+      };
+
+      fsOpts = mkOption {
+        type = listOf str;
+        default =
+          if cfg.fsType == "ext2"
+          then [
+            # An example file system performance tuning option for ext2
+            "noacl"
+            "noatime"
+            "nodiratime"
+          ]
+          else if cfg.fsType == "xfs"
+          then [
+            # An example file system performance tuning option for XFS
+            "logbsize=256k"
+          ]
+          else [];
+        description = ''
+          File system tuning options used during mounting.
+        '';
+      };
+
+      fsType = mkOption {
+        type = enum ["ext2" "xfs"];
+        default = "ext2";
+        description = ''
+          The file system to use for ephemeral storage.
+
+          The block devices will be formatted with this file system. If the
+          file system is to be changed, the instance will need to be
+          re-deployed and then stopped and restarted to re-instantiate the
+          ephemeral block device(s) at which point auto-format and relabelling
+          will occur.
+
+          NOTE: Changing to a file system other than ext2 or xfs will require
+          extending the nixos module code to support the new filesystem(s).
+        '';
+      };
+
+      label = mkOption {
+        type = str;
+        default = "ephemeral";
+        description = ''
+          The block device label to be applied to the ephemeral storage file
+          system.
+
+          Mounting by label allows the underlying device to be either a
+          direct NVMe block device or a RAID array.
+        '';
+      };
+
+      mountPoint = mkOption {
+        type = str;
+        default = "/ephemeral";
+        description = ''
+          The location to mount ephemeral storage.
+        '';
+      };
+
+      postMountScript = mkOption {
+        type = str;
+        default = ''
+          echo "No post mount script defined..."
+        '';
+        description = ''
+          Default post ephemeral block device mount script code, to be embedded
+          inside a bash writeShellApplication wrapper.
+        '';
+      };
+
+      postMountServiceName = mkOption {
+        type = str;
+        default = "ephemeral-post-mount";
+        description = ''
+          The systemd service name for post mount set up, excluding the
+          `.service` suffix.
+        '';
+      };
+
+      raidCfgFile = mkOption {
+        type = str;
+        default = "/etc/mdadm/mdadm.conf";
+        description = ''
+          The dynamically created and mutable raid configuration file for
+          ephemeral storage.
+        '';
+      };
+
+      raidDevice = mkOption {
+        type = str;
+        default = "/dev/md127";
+        description = ''
+          RAID often reverts to /dev/md127 due to auto scan and assemble
+          despite proper use of /etc/mdadm.conf, so to avoid device index
+          switching, default to use of the autoscan index from the time of
+          RAID array creation.
+        '';
+      };
+
+      serviceName = mkOption {
+        type = str;
+        default = "ephemeral-setup";
+        description = ''
+          The systemd service name for formatting ephemeral block devices,
+          excluding the `.service` suffix.
+        '';
+      };
+
+      specialEphemeralInstanceTypePrefixes = mkOption {
+        type = listOf str;
+        default = ["i3" "i7" "trn1"];
+        description = ''
+          Aws ec2 instance type prefixes which contain ephemeral NVMe block
+          devices without also containing the standard `d` identifier in the
+          instance type for disk backed storage.
+        '';
+      };
+
+      symlinkTarget = mkOption {
+        type = str;
+        default = "/dev/ephemeral";
+        description = ''
+          The symlink target linking to the ephemeral block storage file system.
+        '';
+      };
+    };
+
+    config = mkIf hasEphemeral {
+      fileSystems = {
+        "${cfg.label}" = {
+          inherit (cfg) fsType label mountPoint;
+
+          # The systemd service will handle the formatting logic.
+          autoFormat = false;
+
+          options =
+            [
+              # Wait until systemd ephemeral setup is complete so the file system will exist.
+              "x-systemd.requires=${cfg.serviceName}.service"
+              "x-systemd.after=${cfg.serviceName}.service"
+
+              # Required to avoid systemd order cycling problems that otherwise occur.
+              # The ephemeral file system will be auto-mounted on the first access attempt.
+              "x-systemd.automount"
+            ]
+            ++ cfg.fsOpts;
+        };
+      };
+
+      # Make /etc/mdadm.conf reflect the dynamically created mutable raid
+      # config file.
+      environment.etc."mdadm.conf".source = mkForce cfg.raidCfgFile;
+
+      systemd.services = {
+        ${cfg.serviceName} = {
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = getExe (pkgs.writeShellApplication {
+              name = cfg.serviceName;
+
+              runtimeInputs = with pkgs; [e2fsprogs fd jq kmod mdadm util-linux xfsprogs];
+              text = ''
+                set -euo pipefail
+
+                LABEL="${cfg.label}"
+                RAID_CFG="${cfg.raidCfgFile}"
+                RAID_DEV="${cfg.raidDevice}"
+                SYM_TGT="${cfg.symlinkTarget}"
+
+                IS_EMPTY() {
+                  DEV="$1"
+                  RESULT=$(lsblk --fs --json "$DEV" \
+                    | jq -r 'any(.blockdevices[]; (has("children") | not) and (.fstype == null))')
+
+                  if [ "$RESULT" = "true" ]; then
+                    return 0
+                  else
+                    return 1
+                  fi
+                }
+
+                mapfile -t INSTANCE_BD < <(fd 'nvme-Amazon_EC2_NVMe_Instance_Storage_AWS[0-9A-F]{17}$' /dev/disk/by-id/ | sort)
+                NUM_BD="''${#INSTANCE_BD[@]}"
+
+                echo "Number of ephemeral block devices detected are: $NUM_BD, comprised of:"
+                printf "%s\n" "''${INSTANCE_BD[@]}"
+
+                # Check ephemeral storage is available
+                if [ "$NUM_BD" -eq "0" ]; then
+                  echo "No ephemeral block devices found, aborting."
+                  exit 0
+                fi
+
+                # Check if all ephemeral storage is empty
+                EMPTY="true"
+                for DEV in "''${INSTANCE_BD[@]}"; do
+                  if ! IS_EMPTY "$DEV"; then
+                    echo "Device $DEV has a file system or holds partitions."
+                    EMPTY="false"
+                  fi
+                done
+
+                if [ "$EMPTY" = "false" ]; then
+                  echo "One or more ephemeral block devices are not empty; symlinking only..."
+                else
+                  echo "Ephemeral block device(s) appear to be empty, formatting and symlinking..."
+                fi
+
+                # Create the filesystem and symlink as applicable
+                if [ "$NUM_BD" -eq "1" ]; then
+                  if [ "$EMPTY" = "true" ]; then
+                    set -x
+                    mkfs -t ${cfg.fsType} -L "$LABEL" "''${INSTANCE_BD[@]}"
+                  fi
+                  ln -svf "''${INSTANCE_BD[@]}" "$SYM_TGT"
+                  set +x
+                elif [ "$NUM_BD" -gt "1" ]; then
+                  echo "Multiple ephemeral block devices are available..."
+                  if [ "$EMPTY" = "true" ]; then
+                    set -x
+                    mdadm --create "$RAID_DEV" --raid-devices="$NUM_BD" --level=0 "''${INSTANCE_BD[@]}"
+                    mdadm --detail --scan | tee "$RAID_CFG"
+                    mkfs -t ${cfg.fsType} -L "$LABEL" "$RAID_DEV"
+                    ln -svf "$RAID_DEV" "$SYM_TGT"
+                    set +x
+                  else
+                    if [ -b "$RAID_DEV" ]; then
+                      ln -svf "$RAID_DEV" "$SYM_TGT"
+                    fi
+                  fi
+                  exit 0
+                else
+                  echo "The number of ephemeral block devices was not properly recognized: $NUM_BD"
+                  exit 1
+                fi
+              '';
+            });
+          };
+        };
+
+        ${cfg.postMountServiceName} = {
+          after = ["${cfg.label}.mount"];
+          requires = ["${cfg.label}.mount"];
+          wantedBy = ["${cfg.label}.mount"];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = getExe (pkgs.writeShellApplication {
+              name = cfg.serviceName;
+              text = ''
+                set -euo pipefail
+
+                ${cfg.postMountScript}
+              '';
+            });
+          };
+        };
+
+        "${cfg.serviceName}-mount-on-creation" = mkIf cfg.enableMountOnCreation {
+          wantedBy = ["multi-user.target"];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = getExe (pkgs.writeShellApplication {
+              name = "${cfg.serviceName}-mount-on-creation";
+              text = ''
+                set -euo pipefail
+
+                while true; do
+                  echo "Sleeping 10 seconds until mount on created attempt..."
+                  sleep 10
+                  # shellcheck disable=SC2010
+                  if ls -1 / | grep -q ${removePrefix "/" cfg.mountPoint}; then
+                    echo "Found: ${cfg.mountPoint}"
+
+                    # Trigger the systemd auto-mount service
+                    ls ${cfg.mountPoint}
+
+                    touch ${cfg.mountPoint}/.mounted
+
+                    break
+                  fi
+                done
+              '';
+            });
+          };
+        };
+      };
+    };
+  };
+}

--- a/flake/nixosModules/ephemeral.nix
+++ b/flake/nixosModules/ephemeral.nix
@@ -1,4 +1,4 @@
-# nixosModule: profile-aws-ec2-ephemeral
+# nixosModule: ephemeral
 #
 # Originates from:
 # https://github.com/input-output-hk/cardano-parts/blob/main/flake/nixosModules/profile-aws-ec2-ephemeral.nix
@@ -23,7 +23,7 @@ flake: {
 
     cfg = config.services.aws.ec2.ephemeral;
   in {
-    key = ./profile-aws-ec2-ephemeral.nix;
+    key = ./ephemeral.nix;
 
     options.services.aws.ec2.ephemeral = {
       enableMountOnCreation = mkOption {

--- a/flake/nixosModules/nomad-client.nix
+++ b/flake/nixosModules/nomad-client.nix
@@ -5,7 +5,9 @@
     pkgs,
     lib,
     ...
-  }: {
+  }: let
+    inherit (lib) mkForce;
+  in {
     aws.instance.tags.Role = "cardano-perf-client";
 
     services.nomad = {
@@ -48,6 +50,21 @@
             ];
           }
         ];
+      };
+    };
+
+    # This will allow the service to continue retrying until sops keys are in
+    # place, wireguard is up and running and the ephemeral volumes, if any, are
+    # mounted.
+    systemd.services.nomad = {
+      serviceConfig = {
+        Restart = mkForce "always";
+        RestartSec = mkForce 10;
+      };
+
+      unitConfig = {
+        StartLimitIntervalSec = mkForce 0;
+        StartLimitBurst = mkForce 0;
       };
     };
   });

--- a/flake/nixosModules/nomad-server.nix
+++ b/flake/nixosModules/nomad-server.nix
@@ -4,7 +4,9 @@
     config,
     pkgs,
     ...
-  }: {
+  }: let
+    inherit (lib) mkForce;
+  in {
     aws.instance.tags.Role = "cardano-perf-server";
 
     services.nomad = {
@@ -37,6 +39,21 @@
           http_max_conns_per_client = 400;
           rpc_max_conns_per_client = 400;
         };
+      };
+    };
+
+    # This will allow the service to continue retrying until sops keys are in
+    # place, wireguard is up and running and the ephemeral volumes, if any, are
+    # mounted.
+    systemd.services.nomad = {
+      serviceConfig = {
+        Restart = mkForce "always";
+        RestartSec = mkForce 10;
+      };
+
+      unitConfig = {
+        StartLimitIntervalSec = mkForce 0;
+        StartLimitBurst = mkForce 0;
       };
     };
   });

--- a/flake/nixosModules/nomad-ssd.nix
+++ b/flake/nixosModules/nomad-ssd.nix
@@ -3,7 +3,7 @@
     nix.settings.system-features = ["benchmark"];
 
     services.nomad.settings.client.host_volume = {
-      "ephemeral".path = "/dev/ephemeral";
+      "ephemeral".path = "/ephemeral";
     };
 
     # NOTE: the simple nixos fileSystems approach below won't work because upon

--- a/flake/nixosModules/nomad-ssd.nix
+++ b/flake/nixosModules/nomad-ssd.nix
@@ -3,24 +3,22 @@
     nix.settings.system-features = ["benchmark"];
 
     services.nomad.settings.client.host_volume = {
-      "ssd1".path = "/ssd1";
-      "ssd2".path = "/ssd2";
+      "ephemeral".path = "/dev/ephemeral";
     };
 
-    fileSystems = {
-      "/ssd1" = {
-        device = "/dev/nvme1n1";
-        fsType = "ext2";
-        autoFormat = true;
-        options = ["noatime" "nodiratime" "noacl"];
-      };
-
-      "/ssd2" = {
-        device = "/dev/nvme2n1";
-        fsType = "ext2";
-        autoFormat = true;
-        options = ["noatime" "nodiratime" "noacl"];
-      };
-    };
+    # NOTE: the simple nixos fileSystems approach below won't work because upon
+    # reboot, instances with ephemeral disks will randomly re-assign the device
+    # names between gp2/gp3/ephemeral leading to mount failure.
+    #
+    # The solution for this is to use the nixosModule `ephemeral`.
+    #
+    # fileSystems = {
+    #   "/ssd1" = {
+    #     device = "/dev/nvme1n1";
+    #     fsType = "ext2";
+    #     autoFormat = true;
+    #     options = ["noatime" "nodiratime" "noacl"];
+    #   };
+    # };
   };
 }

--- a/perSystem/devShells/default.nix
+++ b/perSystem/devShells/default.nix
@@ -17,13 +17,13 @@ flake: {
           deadnix
           inputs'.colmena.packages.colmena
           just
-          nushellFull
+          nushell
           rain
           self'.packages.opentofu
           sops
           statix
           wireguard-tools
-          nomad
+          self'.packages.nomad
         ];
 
         shellHook = ''

--- a/perSystem/packages/pre-push.nix
+++ b/perSystem/packages/pre-push.nix
@@ -20,7 +20,7 @@
         done
 
         set -x
-        nix build "''${checks[@]}"
+        nix build --accept-flake-config "''${checks[@]}"
       '';
     };
   };

--- a/scripts/recipes-aws.just
+++ b/scripts/recipes-aws.just
@@ -1,0 +1,41 @@
+# AWS specific recipes related to non-Tofu infrastructure.
+# Doing so will make diffing and patching the main repo Justfile easier.
+
+# Describe an aws ec2 machine
+aws-ec2-describe NAME REGION:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 describe-instances --instance-ids "$ID"
+
+# Get an aws ec2 machine id
+aws-ec2-id NAME REGION:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(aws --region {{REGION}} ec2 describe-instances --filters "Name=tag:Name,Values={{NAME}}" --output text --query "Reservations[*].Instances[*].InstanceId")
+  if [ -z "${ID:-}" ]; then
+    echo >&2 "ERROR: Machine {{NAME}} not found in region {{REGION}}"
+    exit 1
+  fi
+  echo "$ID"
+
+# Start an aws ec2 machine
+aws-ec2-start NAME REGION:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 start-instances --instance-ids "$ID"
+
+# Get an aws ec2 machine status
+aws-ec2-status NAME REGION:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 describe-instance-status --include-all-instances --instance-ids "$ID"
+
+# Stop an aws ec2 machine
+aws-ec2-stop NAME REGION:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 stop-instances --instance-ids "$ID"


### PR DESCRIPTION
* Bump nixpkgs -> `25.05`, colmena
* Add just aws recipes for easy ec2 state control
* Make required nixpkgs/colmena updates wrt breaking changes from the flake pin bumps
* Make aws ami declaration compatible with latest nixpkgs tofu requirements
* Modify wireguard service to avoid sops secrets race condition failures
* Modify nomad service to avoid sops/wireguard/ephemeral mount race condition failures
* Add `flake/nixosModules/ephemeral.nix` nixos module to support ephemeral storage mounting and use
* Update client machines, `client-{ap,eu,us}-.*` to use d class variant for NVMe ephemeral storage
* Deploy all machines for new nixpkgs and ephemeral storage
* Make the deployer devfs mount reproducible
* GC old nixpkgs generations