### PR TITLE
Add new tags for CloudF and Tofu resources

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -60,10 +60,21 @@ save-bootstrap-ssh-key:
   $key.values.private_key_openssh | save .ssh_key
   chmod 0600 .ssh_key
 
+# Deploy a cloudFormation stack
 cf STACKNAME:
+  #!/usr/bin/env nu
   mkdir cloudFormation
+  let secretName = (nix eval --raw '.#cluster.generic.costCenter')
+  let costCenter = (
+    sops --kms /dev/null -d secrets/cluster.tfvars.enc
+    | lines
+    | where { |it| $it =~ $secretName }
+    | parse $"($secretName) = \"{secret}\""
+    | get 0.secret
+    | to text
+  )
   nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force 'cloudFormation/{{STACKNAME}}.json'
-  rain deploy --debug --termination-protection --yes ./cloudFormation/{{STACKNAME}}.json
+  rain deploy --debug --params costCenter=($costCenter) --termination-protection ./cloudFormation/{{STACKNAME}}.json
 
 wg-genkey KMS HOSTNAME:
   #!/usr/bin/env nu
@@ -89,9 +100,37 @@ wg-genkeys:
   for node in $nodes { just wg-genkey $kms $node }
 
 tf *ARGS:
-  rm --force cluster.tf.json
-  nix build .#terraform.cluster --out-link cluster.tf.json
-  tofu {{ARGS}}
+  #!/usr/bin/env bash
+  set -euo pipefail
+  IGREEN='\033[1;92m'
+  IRED='\033[1;91m'
+  NC='\033[0m'
+  SOPS=("sops" "--kms" "/dev/null" "--decrypt")
+
+  read -r -a ARGS <<< "{{ARGS}}"
+  if [[ ${ARGS[0]} =~ cluster ]]; then
+    WORKSPACE="${ARGS[0]}"
+    ARGS=("${ARGS[@]:1}")
+  else
+    WORKSPACE="cluster"
+  fi
+
+  unset VAR_FILE
+  if [ -s "secrets/$WORKSPACE.tfvars.enc" ]; then
+    VAR_FILE="secrets/$WORKSPACE.tfvars.enc"
+  fi
+
+  # Everything is currently in one TF workspace, but we can use this to expand in the future if we want
+  # echo -e "Running tofu in the ${IGREEN}$WORKSPACE${NC} workspace..."
+  # rm --force "$WORKSPACE.tf.json"
+  nix build ".#terraform.$WORKSPACE" --out-link "$WORKSPACE.tf.json"
+
+  tofu init -reconfigure
+
+  # If not using a default workspace:
+  # tofu workspace select -or-create "$WORKSPACE"
+
+  tofu "${ARGS[@]:0:1}" ${VAR_FILE:+-var-file=<("${SOPS[@]}" "$VAR_FILE")} "${ARGS[@]:1}"
 
 show-nameservers:
   #!/usr/bin/env nu

--- a/flake/cloudFormation/terraformState.nix
+++ b/flake/cloudFormation/terraformState.nix
@@ -1,18 +1,61 @@
-{config, ...}: {
+{
+  config,
+  lib,
+  ...
+}: {
   flake.cloudFormation.terraformState = let
     inherit (config.flake.cluster) domain bucketName;
+
+    tagWith = name:
+      (lib.mapAttrsToList (n: v: {
+          Key = n;
+          Value = v;
+        }) {
+          inherit
+            (config.flake.cluster.generic)
+            environment
+            function
+            organization
+            owner
+            project
+            repo
+            tribe
+            ;
+        })
+      ++ [
+        {
+          Key = "Name";
+          Value = name;
+        }
+        {
+          Key = "costCenter";
+          Value = {
+            Ref = "costCenter";
+          };
+        }
+      ];
   in {
     AWSTemplateFormatVersion = "2010-09-09";
     Description = "Terraform state handling";
 
+    # The costCenter parameter will be passed to the configuration via a secrets file.
+    # For details, see the just recipe: cf
+    Parameters = {
+      costCenter = {
+        Type = "String";
+        Description = "The costCenter tag";
+      };
+    };
+
     # Resources here will be created in the AWS_REGION and AWS_PROFILE from your
     # environment variables.
     # Execute this using: `just cf terraformState`
-
     Resources = {
       kmsKey = {
         Type = "AWS::KMS::Key";
+        DeletionPolicy = "RetainExceptOnCreate";
         Properties = {
+          Tags = tagWith "kmsKey";
           KeyPolicy."Fn::Sub" = builtins.toJSON {
             Version = "2012-10-17";
             Statement = [
@@ -30,8 +73,10 @@
 
       kmsKeyAlias = {
         Type = "AWS::KMS::Alias";
+        DeletionPolicy = "RetainExceptOnCreate";
         Properties = {
           # This name is used in various places, check before changing it.
+          # KMS aliases do not accept tags
           AliasName = "alias/kmsKey";
           TargetKeyId.Ref = "kmsKey";
         };
@@ -39,13 +84,18 @@
 
       DNSZone = {
         Type = "AWS::Route53::HostedZone";
-        Properties.Name = domain;
+        DeletionPolicy = "RetainExceptOnCreate";
+        Properties = {
+          HostedZoneTags = tagWith domain;
+          Name = domain;
+        };
       };
 
       S3Bucket = {
         Type = "AWS::S3::Bucket";
-        DeletionPolicy = "Retain";
+        DeletionPolicy = "RetainExceptOnCreate";
         Properties = {
+          Tags = tagWith bucketName;
           BucketName = bucketName;
           BucketEncryption.ServerSideEncryptionConfiguration = [
             {
@@ -59,7 +109,9 @@
 
       DynamoDB = {
         Type = "AWS::DynamoDB::Table";
+        DeletionPolicy = "RetainExceptOnCreate";
         Properties = {
+          Tags = tagWith "terraform-DynamoDB";
           TableName = "terraform";
 
           KeySchema = [

--- a/flake/cluster.nix
+++ b/flake/cluster.nix
@@ -20,11 +20,18 @@
     bucketName = "cardano-perf-terraform";
 
     generic = {
-      organization = "iog";
+      organization = "ioe";
       tribe = "coretech";
       function = "cardano-perf";
       repo = "https://github.com/input-output-hk/cardano-perf";
-      environment = "generic";
+
+      # Tags below are required by IT/Finance
+      owner = "ioe";
+      environment = "benchmarking";
+      project = "cardano-perf";
+
+      # This is the tf var secrets name located in secrets/cluster.tfvars.enc
+      costCenter = "tag_costCenter";
     };
   };
 }

--- a/flake/nixosModules/aws-ec2.nix
+++ b/flake/nixosModules/aws-ec2.nix
@@ -84,7 +84,6 @@
 
     config = {
       aws.instance.tags = {
-        inherit (self.cluster.generic) organization tribe function repo;
         environment = name;
         group = name;
         Name = name;

--- a/flake/terraform/cluster.nix
+++ b/flake/terraform/cluster.nix
@@ -27,6 +27,28 @@
     cluster.regions;
 
   mapRegions = f: lib.foldl' lib.recursiveUpdate {} (lib.forEach regions f);
+
+  sensitiveString = {
+    type = "string";
+    sensitive = true;
+    nullable = false;
+  };
+
+  defaultTags = {
+    inherit
+      (self.cluster.generic)
+      environment
+      function
+      organization
+      owner
+      project
+      repo
+      tribe
+      ;
+
+    # costCenter is saved as a secret
+    costCenter = "\${var.${self.cluster.generic.costCenter}}";
+  };
 in {
   flake.terraform.cluster = inputs.terranix.lib.terranixConfiguration {
     system = "x86_64-linux";
@@ -49,10 +71,19 @@ in {
           };
         };
 
+        variable = {
+          # costCenter tag should remain secret in public repos
+          "${self.cluster.generic.costCenter}" = sensitiveString;
+        };
+
         provider.aws = lib.forEach (builtins.attrNames cluster.regions) (region: {
           inherit region;
           alias = underscore region;
-          default_tags.tags = self.cluster.generic;
+
+          # Default tagging is inconsistent across aws resources, but including
+          # it may help tag some resources that might have otherwise been
+          # missed.
+          default_tags.tags = defaultTags;
         });
 
         # Common parameters:
@@ -77,6 +108,19 @@ in {
                 {
                   name = "architecture";
                   values = [(builtins.head (lib.splitString "-" system))];
+                }
+              ];
+            };
+          });
+
+          # Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+          aws_availability_zones = mapRegions ({region, ...}: {
+            ${region} = {
+              provider = "aws.${region}";
+              filter = [
+                {
+                  name = "opt-in-status";
+                  values = ["opt-in-not-required"];
                 }
               ];
             };
@@ -110,13 +154,79 @@ in {
               }
             ];
           };
+
+          aws_internet_gateway = mapRegions ({region, ...}: {
+            ${region} = {
+              provider = "aws.${region}";
+              filter = [
+                {
+                  name = "attachment.vpc-id";
+                  values = ["\${data.aws_vpc.${region}.id}"];
+                }
+              ];
+              depends_on = ["data.aws_vpc.${region}"];
+            };
+          });
+
+          aws_route_table = mapRegions ({region, ...}: {
+            ${region} = {
+              provider = "aws.${region}";
+              route_table_id = "\${data.aws_vpc.${region}.main_route_table_id}";
+              depends_on = ["data.aws_vpc.${region}"];
+            };
+          });
+
+          aws_subnet = mapRegions ({region, ...}: {
+            ${region} = {
+              provider = "aws.${region}";
+              # The index of the map is used to assign an ipv6 subnet network
+              # id offset in the aws_default_subnet ipv6_cidr_block resource
+              # arg.
+              #
+              # While az ids are consistent across aws orgs, they are not
+              # implemented in all regions, therefore we'll use az names as
+              # indexed values.
+              #
+              # Ref:
+              #   https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet#availability_zone_id
+              #
+              for_each = "\${{for i, az in data.aws_availability_zones.${region}.names : i => az}}";
+              availability_zone = "\${element(data.aws_availability_zones.${region}.names, each.key)}";
+              default_for_az = true;
+            };
+          });
+
+          aws_vpc = mapRegions ({region, ...}: {
+            ${region} = {
+              provider = "aws.${region}";
+              default = true;
+            };
+          });
         };
+
+        # Debug output
+        # output =
+        #   mapRegions ({region, ...}: {
+        #     "aws_availability_zones_${region}".value = "\${data.aws_availability_zones.${region}.names}";
+        #   })
+        #   // mapRegions ({region, ...}: {
+        #     "aws_internet_gateway_${region}".value = "\${data.aws_internet_gateway.${region}}";
+        #   })
+        #   // mapRegions ({region, ...}: {
+        #     "aws_route_table_${region}".value = "\${data.aws_route_table.${region}}";
+        #   })
+        #   // mapRegions ({region, ...}: {
+        #     "aws_subnet_${region}".value = "\${data.aws_subnet.${region}}";
+        #   })
+        #   // mapRegions ({region, ...}: {
+        #     "aws_vpc_${region}".value = "\${data.aws_vpc.${region}}";
+        #   });
 
         resource = {
           aws_instance = mapNodes (
             _: node:
               {
-                inherit (node.aws.instance) count instance_type tags;
+                inherit (node.aws.instance) count instance_type;
                 provider = awsProviderFor node.aws.region;
                 ami = "\${data.aws_ami.nixos_${system}_${underscore node.aws.region}.id}";
                 iam_instance_profile = "\${aws_iam_instance_profile.ec2_profile.name}";
@@ -126,11 +236,19 @@ in {
                   "\${aws_security_group.common_${underscore node.aws.region}[0].id}"
                 ];
 
+                # Provider level `default_tags` are automatically inherited at
+                # the instance level.  Instance specific tags defined in
+                # flake/colmena.nix are merged.
+                tags = node.aws.instance.tags or {};
+
                 root_block_device = {
                   volume_type = "gp3";
                   inherit (node.aws.instance.root_block_device) volume_size;
                   iops = 3000;
                   delete_on_termination = true;
+
+                  # Default tags are not inherited to the volume level automatically.
+                  tags = defaultTags // node.aws.instance.tags or {};
                 };
 
                 metadata_options = {
@@ -149,6 +267,7 @@ in {
           aws_iam_instance_profile.ec2_profile = {
             name = "ec2Profile";
             role = "\${aws_iam_role.ec2_role.name}";
+            tags = defaultTags;
           };
 
           aws_iam_role.ec2_role = {
@@ -163,6 +282,8 @@ in {
                 }
               ];
             };
+
+            tags = defaultTags;
           };
 
           aws_iam_role_policy_attachment = let
@@ -198,6 +319,8 @@ in {
                   }
                 ];
               };
+
+              tags = defaultTags;
             };
 
             ec2_discover = {
@@ -212,6 +335,8 @@ in {
                   }
                 ];
               };
+
+              tags = defaultTags;
             };
 
             s3_access_policy = {
@@ -234,6 +359,8 @@ in {
                   }
                 ];
               };
+
+              tags = defaultTags;
             };
           };
 
@@ -248,13 +375,17 @@ in {
               provider = awsProviderFor region;
               key_name = "bootstrap";
               public_key = "\${tls_private_key.bootstrap.public_key_openssh}";
+              tags = defaultTags;
             };
           });
 
           aws_eip = mapNodes (name: node: {
-            inherit (node.aws.instance) count tags;
+            inherit (node.aws.instance) count;
             provider = awsProviderFor node.aws.region;
             instance = "\${aws_instance.${name}[0].id}";
+
+            # Provider level `default_tags` are automatically inherited.
+            tags = node.aws.instance.tags or {};
           });
 
           aws_eip_association = mapNodes (name: node: {
@@ -270,6 +401,7 @@ in {
             iops = 3000;
             throughput = 125; # MB/s
             size = 12000;
+            tags = {Name = "deployer_volume";} // defaultTags;
           };
 
           aws_volume_attachment.deployer_volume = {
@@ -350,6 +482,8 @@ in {
                     protocol = "-1";
                   })
                 ];
+
+                tags = defaultTags;
               };
             });
 
@@ -363,7 +497,7 @@ in {
 
           aws_s3_bucket.deploy = {
             bucket = "${self.cluster.profile}-deploy";
-            tags = self.cluster.generic;
+            tags = defaultTags;
           };
 
           aws_s3_bucket_policy.public_read_access = {
@@ -396,6 +530,8 @@ in {
                 }
               ];
             };
+
+            tags = defaultTags;
           };
 
           aws_s3_bucket_public_access_block.deploy = {

--- a/secrets/cluster.tfvars.enc
+++ b/secrets/cluster.tfvars.enc
@@ -1,0 +1,17 @@
+{
+	"data": "ENC[AES256_GCM,data:1fHpgyxSpw3MwSDUtHa8m4zBY+VpRt3IQQ==,iv:k5aPi2g5ty6OpOUBmiWHuPtxQS4xPNfP9J12eCwxXr0=,tag:Tjs+ow/w+QP4eeUYBjtEIQ==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:eu-central-1:634968354090:alias/kmsKey",
+				"created_at": "2025-11-08T02:12:57Z",
+				"enc": "AQICAHjERJSkkd02ChDwvtPUUy9LjCMyl4XTwUygBtpfDd/1pAFtGTFEu54Zz1K63rAq3QKYAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMWsz/DWswur+Hr7iAAgEQgDs4R92lqRAguZShVRiVmUgZc2tF75qDGRd/D/G/Q/jShuRKeSoR8jAClbOcqiSQCmEY5xFB5dpTdZLhaA==",
+				"aws_profile": ""
+			}
+		],
+		"lastmodified": "2025-11-08T02:12:58Z",
+		"mac": "ENC[AES256_GCM,data:HYoCpB81q7idBOjQCzt12xRwmuE1csa0CvWhwosYDKDWlaQWOtDu37HWcOBy51rFwRPXjzatCWaGS5kdIrfI4K55lKDhe71Ohku1eNGwIL8m65ClFQoLqbZnCMiajh5qMkk9iq8lS2Jet/z6gsw12p32UIBpnskbYm87vnIEeDY=,iv:3OP58VWHnfd69cr1r4iTL8Z13Lv16qgUXgby70L0wss=,tag:D+EWr20BQvymPVkTeostpA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
* Adds new resource tags to both cloudFormation and tofu resources: `owner`, `project`, `costCenter`
* Updates the pre-existing `organization` and `environment` tags
* Treats costCenter tag as secret and adds a corresponding secrets file
* Updates justfile, cloudFormation state template and tofu cluster definition files to accommodate
* Adds some default resource tofu defns in prep for ipv6 and default resource tagging